### PR TITLE
Enable multi-symbol datasets and HF-ready downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.DS_Store
+.env
+.venv/
+artifacts/
+data/
+!stonkex/data/
+.streamlit/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,185 @@
 # StonkEx
+
+StonkEx is a GPU-optimized research sandbox for training transformer-based models on candlestick (OHLCV) data and visualizing forecasts in real time. It provides:
+
+- **Data pipeline** for downloading, resampling, and windowing stock candles.
+- **PyTorch training stack** with automatic mixed precision tuned for NVIDIA RTX 4080 GPUs and Intel i9-class CPUs.
+- **Streamlit dashboards** to monitor training metrics and interactively preview model forecasts over translucent candlestick overlays.
+- **Rich instrumentation** including JSONL logs, checkpointing, early stopping, and reproducible hyperparameter capture.
+
+## Project structure
+
+```
+stonkex/
+├── config.py               # Experiment configuration dataclasses
+├── data/                   # Dataset + preprocessing utilities
+├── inference/              # Model loading helpers
+├── models/                 # Transformer architecture
+├── training/               # Trainer, callbacks, utilities
+├── visualization/          # Plotly candlestick helpers
+app/
+├── dashboard.py            # Training monitor UI (Streamlit)
+├── predictor.py            # Forecast visualization UI (Streamlit)
+scripts/
+├── prepare_data.py         # Download & preprocess candles (yfinance)
+├── train.py                # Main training CLI
+├── evaluate.py             # Offline evaluation script
+tests/                      # Pytest-based smoke tests
+```
+
+## Installation
+
+1. Create and activate a Python 3.10+ environment.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   pip install -e .[dev]
+   ```
+
+> **Tip:** For maximum throughput on an RTX 4080 Super, install the latest CUDA-enabled PyTorch wheel from https://pytorch.org/get-started/locally/.
+
+## Data preparation
+
+### Single-symbol download
+
+Use `scripts/prepare_data.py` to download OHLCV candles via *yfinance*:
+
+```bash
+python scripts/prepare_data.py AAPL 2020-01-01 2024-01-01 --interval 1h --output data/aapl_1h.csv
+```
+
+The script can optionally resample to a coarser interval using the `--resample` argument.
+
+### 70-symbol research universe
+
+For training on "tons of data," bootstrap a multi-gigabyte research universe covering 70 blue-chip tickers (the defaults span tech, finance, industrials, energy, retail, utilities, etc.). The helper below downloads each symbol into its own CSV, caps the aggregate size (default 1 GB, configurable up to 3 GB), and resumes partial runs:
+
+```bash
+python scripts/prepare_universe.py 2015-01-01 2024-01-01 \
+  --interval 1h \
+  --output-dir data/universe \
+  --max-bytes 2.5
+```
+
+- Pass `--symbols-file symbols.txt` to load a newline-delimited ticker list, or `--symbols TICK1 TICK2 ...` to override the defaults. Both options can be combined.
+- Use `--resample 4H` (or any pandas rule) to aggregate before saving if the raw interval produces more data than your space budget.
+- Subsequent invocations resume without re-downloading existing CSVs unless `--no-resume` is provided.
+
+Once the download finishes you will have `data/universe/*.csv` ready for training and validation. The trainer automatically infers the number of symbols and windows without additional configuration.
+
+## Training
+
+Launch training with GPU-optimized defaults:
+
+```bash
+python scripts/train.py \
+  --data-path data/aapl_1h.csv \
+  --input-window 192 \
+  --horizon 24 \
+  --batch-size 256 \
+  --epochs 150 \
+  --d-model 512 \
+  --nhead 8 \
+  --ff-dim 1024
+```
+
+To train on the 70-symbol universe, point `--data-path` at the directory containing the per-symbol CSVs:
+
+```bash
+python scripts/train.py \
+  --data-path data/universe \
+  --input-window 192 \
+  --horizon 24 \
+  --batch-size 256 \
+  --epochs 150
+```
+
+The script prints the number of rows and symbols detected and keeps sliding windows confined within each ticker so that sequences never bleed across companies.
+
+### CPU / Hugging Face Spaces (zero GPU) tips
+
+When running inside a CPU-only environment such as a zero-GPU Gradient Space on Hugging Face, use the CPU execution mode so the script automatically disables CUDA-only features and right-sizes batch sizes and dataloader workers:
+
+```bash
+python scripts/prepare_universe.py 2018-01-01 2024-01-01 \
+  --interval 1h \
+  --output-dir data/universe \
+  --max-bytes 1.0
+
+python scripts/train.py \
+  --data-path data/universe \
+  --device cpu \
+  --batch-size 64 \
+  --num-workers 0 \
+  --mixed-precision False \
+  --d-model 256 \
+  --ff-dim 512 \
+  --epochs 50
+```
+
+The trainer will automatically cap the batch size at 64 for CPU runs and skip CUDA AMP. On Spaces, set `STREAMLIT_SERVER_ADDRESS=0.0.0.0` and `STREAMLIT_SERVER_PORT=7860` before launching the Streamlit apps to expose them to the public interface.
+
+Key features of the training pipeline:
+
+- Automatic mixed precision (AMP) enabled by default (`--no-mixed-precision` to disable).
+- Cosine annealing learning-rate scheduler with AdamW optimizer tuned for transformer workloads.
+- Gradient clipping, gradient accumulation, and checkpointing under `artifacts/checkpoints/`.
+- JSONL training logs at `artifacts/logs/training_log.jsonl` and hyperparameter snapshots at `artifacts/hparams.json`.
+- Final artifact (`artifacts/final_model.pt`) bundles the model state, optimizer, scheduler, and normalization statistics for deployment.
+
+Resume from a checkpoint using `--resume artifacts/checkpoints/epoch_XXXX.pt`.
+
+For automated Spaces launches, wrap the two commands above (universe download + CPU training) inside `start.sh` or the Space’s `app.py`. Because downloads resume, repeated deployments won’t waste bandwidth, and the CLI emits progress plus per-symbol summaries for debugging.
+
+## Monitoring UI
+
+Start the Streamlit dashboard to watch training progress:
+
+```bash
+streamlit run app/dashboard.py
+```
+
+Select the artifact directory (`artifacts/` by default) and click **Refresh data** to update loss curves, live metrics, and hyperparameters.
+
+## Forecast visualization UI
+
+After training, preview translucent forecasts over candlesticks:
+
+```bash
+streamlit run app/predictor.py
+```
+
+Upload the generated `artifacts/final_model.pt` along with a CSV containing recent OHLCV candles. Adjust the input window and horizon to align with training settings. The app renders:
+
+- A translucent dashed overlay representing the model’s predicted price trajectory.
+- Candlestick chart of the recent history and (if available) realized future prices.
+- Downloadable JSON with the forecast series for downstream integrations.
+
+## Evaluation
+
+Compute validation MSE for a saved checkpoint:
+
+```bash
+python scripts/evaluate.py --data-path data/aapl_1h.csv --model-path artifacts/final_model.pt
+```
+
+## Testing
+
+Run the automated smoke tests:
+
+```bash
+pytest
+```
+
+These tests ensure dataset windowing, transformer outputs, and the trainer loop operate as expected.
+
+## Troubleshooting & debugging
+
+- Training emits verbose logs; adjust logging verbosity via `STONKEX_LOG_LEVEL` environment variable.
+- `artifacts/logs/training_log.jsonl` can be tailed for live debugging or loaded into pandas for analysis.
+- Checkpoint files store optimizer + scheduler states for full recovery.
+- For GPU memory overflows, reduce `--batch-size` or `--d-model`; for CPU-bound dataloading, tweak `--num-workers`.
+
+## License
+
+This repository is provided as-is for experimentation.

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -1,0 +1,81 @@
+"""Streamlit dashboard to monitor training progress in real time."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+DEFAULT_ARTIFACT_DIR = Path("artifacts")
+
+
+def load_history(log_path: Path) -> pd.DataFrame:
+    if not log_path.exists():
+        return pd.DataFrame(columns=["epoch", "step", "train_loss", "val_loss"])
+    records = []
+    with log_path.open("r", encoding="utf-8") as fp:
+        for line in fp:
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    if not records:
+        return pd.DataFrame(columns=["epoch", "step", "train_loss", "val_loss"])
+    frame = pd.DataFrame(records)
+    return frame.sort_values("epoch")
+
+
+def load_hyperparameters(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as fp:
+        try:
+            return json.load(fp)
+        except json.JSONDecodeError:
+            return {}
+
+
+def main() -> None:
+    st.set_page_config(page_title="StonkEx Training Dashboard", layout="wide")
+    st.title("📈 StonkEx Training Monitor")
+
+    artifact_dir = Path(st.sidebar.text_input("Artifact directory", value=str(DEFAULT_ARTIFACT_DIR)))
+    log_path = artifact_dir / "logs" / "training_log.jsonl"
+    hparams_path = artifact_dir / "hparams.json"
+
+    if st.sidebar.button("Refresh data"):
+        st.experimental_rerun()
+
+    history = load_history(log_path)
+    if history.empty:
+        st.info("No training history found yet. Start `python scripts/train.py ...` to populate logs.")
+        st.stop()
+
+    latest = history.iloc[-1]
+    col_epoch, col_train, col_val = st.columns(3)
+    col_epoch.metric("Epoch", int(latest["epoch"]))
+    col_train.metric("Train Loss", f"{latest['train_loss']:.6f}")
+    if pd.notna(latest.get("val_loss")):
+        col_val.metric("Validation Loss", f"{latest['val_loss']:.6f}")
+    else:
+        col_val.metric("Validation Loss", "N/A")
+
+    chart_data = history.set_index("epoch")[["train_loss"]]
+    if "val_loss" in history.columns:
+        chart_data["val_loss"] = history.set_index("epoch")["val_loss"]
+    st.line_chart(chart_data, height=320)
+
+    st.subheader("Training Log")
+    st.dataframe(history.tail(50))
+
+    hparams = load_hyperparameters(hparams_path)
+    if hparams:
+        st.subheader("Hyperparameters")
+        st.json(hparams)
+
+    st.caption("Use the refresh button to update metrics while training is running.")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/predictor.py
+++ b/app/predictor.py
@@ -1,0 +1,95 @@
+"""Streamlit application for interactive forecasting visualization."""
+from __future__ import annotations
+
+import io
+import json
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+import torch
+
+from stonkex.data.datasets import CANDLESTICK_COLUMNS, SequenceWindow, ensure_datetime_index
+from stonkex.models.transformer import TemporalTransformer, TransformerConfig
+from stonkex.visualization.chart import candlestick_chart
+
+
+st.set_page_config(page_title="StonkEx Predictor", layout="wide")
+st.title("🔮 StonkEx Inference Console")
+
+st.sidebar.header("Inputs")
+model_file = st.sidebar.file_uploader("Model artifact (.pt)", type=["pt"])
+data_file = st.sidebar.file_uploader("Candlestick CSV", type=["csv"])
+input_window = st.sidebar.number_input("Input window", min_value=16, max_value=1024, value=192, step=8)
+horizon = st.sidebar.number_input("Forecast horizon", min_value=1, max_value=256, value=24, step=1)
+run_button = st.sidebar.button("Run inference")
+
+def load_model(buffer: bytes, forecast_horizon: int) -> tuple[TemporalTransformer, dict | None]:
+    artifact = torch.load(io.BytesIO(buffer), map_location="cpu")
+    if isinstance(artifact, dict) and "model_state_dict" in artifact:
+        model_config = artifact.get("model_config") or {}
+        config = TransformerConfig(
+            input_dim=model_config.get("input_dim", len(CANDLESTICK_COLUMNS)),
+            d_model=model_config.get("d_model", 512),
+            nhead=model_config.get("nhead", 8),
+            num_layers=model_config.get("num_layers", 6),
+            dim_feedforward=model_config.get("dim_feedforward", 1024),
+            dropout=model_config.get("dropout", 0.1),
+            horizon=model_config.get("horizon", forecast_horizon),
+        )
+        model = TemporalTransformer(config)
+        model.load_state_dict(artifact["model_state_dict"])
+        model.eval()
+        return model, artifact.get("normalization")
+    raise RuntimeError("Invalid model artifact format")
+
+
+def prepare_frame(file_buffer: bytes) -> pd.DataFrame:
+    frame = pd.read_csv(io.BytesIO(file_buffer))
+    frame = ensure_datetime_index(frame).reset_index()
+    return frame
+
+
+if run_button:
+    if not model_file or not data_file:
+        st.warning("Please upload both a model artifact and a CSV dataset")
+        st.stop()
+
+    model, normalization = load_model(model_file.getvalue(), horizon)
+    frame = prepare_frame(data_file.getvalue())
+
+    if len(frame) < input_window + horizon:
+        st.error("Dataset is too small for the selected window and horizon")
+        st.stop()
+
+    window = SequenceWindow(input_window=input_window, horizon=horizon)
+    recent = frame.tail(window.input_window)
+    if normalization and normalization.get("feature_columns"):
+        feature_cols = [col for col in normalization["feature_columns"] if col in recent.columns]
+    else:
+        feature_cols = [col for col in CANDLESTICK_COLUMNS if col in recent.columns]
+    features = recent[feature_cols]
+    values = torch.tensor(features.to_numpy(dtype=np.float32)).unsqueeze(0)
+
+    if normalization:
+        mean = torch.tensor([normalization["mean"].get(col, float(features[col].mean())) for col in features.columns], dtype=torch.float32)
+        std = torch.tensor([normalization["std"].get(col, float(features[col].std() or 1.0)) for col in features.columns], dtype=torch.float32)
+        std[std == 0] = 1
+        values = (values - mean) / std
+
+    with torch.no_grad():
+        prediction = model(values)
+    prediction = prediction.squeeze(0).cpu().numpy()
+
+    st.subheader("Forecast Preview")
+    fig = candlestick_chart(frame.tail(window.input_window + horizon), pd.Series(prediction), prediction_horizon=horizon)
+    st.plotly_chart(fig, use_container_width=True)
+
+    st.download_button(
+        "Download predictions",
+        data=json.dumps({"forecast": prediction.tolist()}),
+        file_name="stonkex_forecast.json",
+        mime="application/json",
+    )
+else:
+    st.info("Upload a trained model and dataset to visualize predictions.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "stonkex"
+version = "0.1.0"
+description = "GPU-optimized transformer forecaster for candlestick data"
+authors = [{ name = "StonkEx" }]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "torch>=2.1.0",
+  "pandas>=1.5",
+  "numpy>=1.23",
+  "scikit-learn>=1.1",
+  "yfinance>=0.2",
+  "plotly>=5.17",
+  "streamlit>=1.28",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest",
+]
+
+[tool.setuptools.packages.find]
+include = ["stonkex*"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+python_files = "test_*.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+torch>=2.1.0
+pandas>=1.5
+numpy>=1.23
+scikit-learn>=1.1
+yfinance>=0.2
+plotly>=5.17
+streamlit>=1.28

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -1,0 +1,89 @@
+"""Evaluate a trained StonkEx model on a validation dataset."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader
+
+from stonkex.data.datasets import (
+    CandlestickDataset,
+    NormalizationStats,
+    SequenceWindow,
+    ensure_datetime_index,
+)
+from stonkex.models.transformer import TemporalTransformer, TransformerConfig
+from stonkex.training.utils import resolve_device
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate a trained model")
+    parser.add_argument("--data-path", type=Path, required=True)
+    parser.add_argument("--model-path", type=Path, required=True)
+    parser.add_argument("--input-window", type=int, default=192)
+    parser.add_argument("--horizon", type=int, default=24)
+    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--d-model", type=int, default=512)
+    parser.add_argument("--nhead", type=int, default=8)
+    parser.add_argument("--num-layers", type=int, default=6)
+    parser.add_argument("--ff-dim", type=int, default=1024)
+    parser.add_argument("--dropout", type=float, default=0.1)
+    parser.add_argument(
+        "--device",
+        choices=["auto", "cpu", "cuda"],
+        default="auto",
+        help="Execution device for evaluation.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    frame = pd.read_csv(args.data_path)
+    frame = ensure_datetime_index(frame).reset_index()
+
+    window = SequenceWindow(input_window=args.input_window, horizon=args.horizon)
+    dataset = CandlestickDataset(frame, window)
+    stats = NormalizationStats(mean=dataset.mean, std=dataset.std)
+    dataset = CandlestickDataset(frame, window, stats=stats)
+    device = resolve_device(args.device)
+    loader = DataLoader(
+        dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        pin_memory=device.type == "cuda",
+    )
+
+    model_config = TransformerConfig(
+        input_dim=len(dataset.feature_columns),
+        d_model=args.d_model,
+        nhead=args.nhead,
+        num_layers=args.num_layers,
+        dim_feedforward=args.ff_dim,
+        dropout=args.dropout,
+        horizon=args.horizon,
+    )
+    model = TemporalTransformer(model_config).to(device)
+
+    checkpoint = torch.load(args.model_path, map_location=device)
+    state_dict = checkpoint["model_state_dict"] if isinstance(checkpoint, dict) else checkpoint
+    model.load_state_dict(state_dict)
+    model.eval()
+
+    mse_loss = torch.nn.MSELoss()
+    total_loss = 0.0
+    with torch.no_grad():
+        for inputs, targets in loader:
+            inputs = inputs.to(device)
+            targets = targets.to(device)
+            outputs = model(inputs)
+            loss = mse_loss(outputs, targets)
+            total_loss += loss.item()
+    avg_loss = total_loss / len(loader)
+    print(f"Validation MSE: {avg_loss:.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -1,0 +1,42 @@
+"""CLI to download and preprocess candlestick data."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from stonkex.data.preprocessing import DataDownloadConfig, download_candles, resample_timeframe, save_dataframe
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Download and preprocess stock data")
+    parser.add_argument("symbol", help="Ticker symbol, e.g. AAPL")
+    parser.add_argument("start", help="Start date, e.g. 2020-01-01")
+    parser.add_argument("end", help="End date, e.g. 2024-01-01")
+    parser.add_argument("--interval", default="1h", help="Download interval (default: 1h)")
+    parser.add_argument("--resample", default=None, help="Optional pandas resample rule (e.g. '4H')")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/raw.csv"),
+        help="Path to save the processed dataset",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = DataDownloadConfig(
+        symbol=args.symbol,
+        start=args.start,
+        end=args.end,
+        interval=args.interval,
+    )
+    frame = download_candles(config)
+    if args.resample:
+        frame = resample_timeframe(frame, args.resample)
+    save_dataframe(frame, args.output)
+    print(f"Saved dataset to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare_universe.py
+++ b/scripts/prepare_universe.py
@@ -1,0 +1,89 @@
+"""Download a multi-symbol OHLCV universe ready for training."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from stonkex.data import (
+    DEFAULT_SYMBOLS,
+    download_symbol_universe,
+    load_symbol_universe,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Download OHLCV data for many tickers at once")
+    parser.add_argument("start", help="Start date, e.g. 2015-01-01")
+    parser.add_argument("end", help="End date, e.g. 2024-01-01")
+    parser.add_argument("--interval", default="1h", help="Download interval (default: 1h)")
+    parser.add_argument(
+        "--resample",
+        default=None,
+        help="Optional pandas resample rule for coarser timeframes (e.g. '4H' or '1D')",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/universe"),
+        help="Directory to store per-symbol CSV files",
+    )
+    parser.add_argument(
+        "--symbols",
+        nargs="*",
+        help="Explicit space-separated ticker symbols. Overrides defaults when provided.",
+    )
+    parser.add_argument(
+        "--symbols-file",
+        type=Path,
+        help="Path to a newline-delimited list of ticker symbols. Combined with --symbols when both are provided.",
+    )
+    parser.add_argument(
+        "--min-symbols",
+        type=int,
+        default=70,
+        help="Require at least this many tickers to satisfy the training universe.",
+    )
+    parser.add_argument(
+        "--max-bytes",
+        type=float,
+        default=1.0,
+        help="Maximum aggregate CSV size in gigabytes. Increase (<=3) for longer histories.",
+    )
+    parser.add_argument(
+        "--no-resume",
+        action="store_true",
+        help="Disable resume logic and re-download data even if CSVs already exist.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    symbols = load_symbol_universe(args.symbols, symbols_file=args.symbols_file, min_symbols=args.min_symbols)
+    limit_bytes = int(min(max(args.max_bytes, 0.1), 3.0) * (1024**3))
+    print(f"Preparing universe with {len(symbols)} tickers (limit: {limit_bytes / (1024**3):.2f} GB)")
+    result = download_symbol_universe(
+        symbols,
+        start=args.start,
+        end=args.end,
+        interval=args.interval,
+        output_dir=args.output_dir,
+        resample=args.resample,
+        max_bytes=limit_bytes,
+        resume=not args.no_resume,
+    )
+    print("Downloaded files:")
+    for path in result.paths:
+        size_mb = path.stat().st_size / (1024**2)
+        print(f"  {path} ({size_mb:.2f} MB)")
+    print(
+        "Summary: "
+        f"{result.total_rows} rows across {len(result.symbols)} symbols, "
+        f"total size {result.total_bytes / (1024**3):.2f} GB"
+    )
+    print("Default symbol universe:" if not args.symbols and not args.symbols_file else "Symbols used:")
+    print(", ".join(result.symbols) if result.symbols else ", ".join(DEFAULT_SYMBOLS))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,0 +1,320 @@
+"""Train the StonkEx transformer forecaster."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+import torch
+from torch.optim.lr_scheduler import CosineAnnealingLR
+from torch.utils.data import DataLoader
+
+from stonkex.config import DatasetConfig, ExperimentConfig, OptimizerConfig, TrainerConfig
+from stonkex.data.datasets import (
+    CANDLESTICK_COLUMNS,
+    CandlestickDataset,
+    NormalizationStats,
+    SequenceWindow,
+    split_train_validation,
+)
+from stonkex.data.universe import load_universe_dataframe
+from stonkex.models.transformer import TemporalTransformer, TransformerConfig
+from stonkex.training.callbacks import EarlyStopping, HistoryTracker, JSONLLogger, ModelCheckpoint
+from stonkex.training.trainer import Trainer
+from stonkex.training.utils import (
+    configure_logging,
+    ensure_dir,
+    log_hyperparameters,
+    resolve_device,
+    seed_everything,
+)
+
+
+def _default_worker_count() -> int:
+    cpu_count = os.cpu_count() or 1
+    if cpu_count <= 2:
+        return 0
+    return min(4, cpu_count - 1)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train the StonkEx AI model")
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        required=True,
+        help="Path to a CSV file or directory of per-symbol CSV files",
+    )
+    parser.add_argument("--output-dir", type=Path, default=Path("artifacts"), help="Directory for outputs")
+    parser.add_argument("--input-window", type=int, default=192, help="Number of timesteps for input window")
+    parser.add_argument("--horizon", type=int, default=24, help="Forecast horizon (timesteps)")
+    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--epochs", type=int, default=100)
+    parser.add_argument("--lr", type=float, default=3e-4)
+    parser.add_argument("--weight-decay", type=float, default=1e-4)
+    parser.add_argument("--train-ratio", type=float, default=0.8)
+    parser.add_argument(
+        "--mixed-precision",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable/disable automatic mixed precision (default: enabled)",
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=_default_worker_count(),
+        help="Dataloader worker processes (default adapts to CPU cores)",
+    )
+    parser.add_argument("--gradient-accumulation", type=int, default=1)
+    parser.add_argument("--max-grad-norm", type=float, default=1.0)
+    parser.add_argument("--d-model", type=int, default=512)
+    parser.add_argument("--nhead", type=int, default=8)
+    parser.add_argument("--num-layers", type=int, default=6)
+    parser.add_argument("--ff-dim", type=int, default=1024)
+    parser.add_argument("--dropout", type=float, default=0.1)
+    parser.add_argument("--checkpoint-every", type=int, default=1)
+    parser.add_argument("--early-stopping", type=int, default=15)
+    parser.add_argument("--resume", type=Path, default=None, help="Optional checkpoint to resume")
+    parser.add_argument(
+        "--device",
+        choices=["auto", "cpu", "cuda"],
+        default="auto",
+        help="Execution device. Defaults to GPU when available, otherwise CPU.",
+    )
+    return parser.parse_args()
+
+
+def build_config(args: argparse.Namespace, data_path: Path) -> ExperimentConfig:
+    dataset = DatasetConfig(
+        data_path=data_path,
+        input_window=args.input_window,
+        horizon=args.horizon,
+        train_ratio=args.train_ratio,
+    )
+    model = TransformerConfig(
+        input_dim=len(CANDLESTICK_COLUMNS),
+        d_model=args.d_model,
+        nhead=args.nhead,
+        num_layers=args.num_layers,
+        dim_feedforward=args.ff_dim,
+        dropout=args.dropout,
+        horizon=args.horizon,
+    )
+    optimizer = OptimizerConfig(lr=args.lr, weight_decay=args.weight_decay)
+    trainer = TrainerConfig(
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        gradient_accumulation=args.gradient_accumulation,
+        mixed_precision=args.mixed_precision,
+        max_grad_norm=args.max_grad_norm,
+        output_dir=args.output_dir,
+        early_stopping_patience=args.early_stopping,
+        checkpoint_interval=args.checkpoint_every,
+        seed=args.seed,
+    )
+    return ExperimentConfig(dataset=dataset, model=model, optimizer=optimizer, trainer=trainer)
+
+
+def _discover_csv_files(path: Path) -> list[Path]:
+    if path.is_dir():
+        csvs = sorted(p for p in path.glob("*.csv") if p.is_file())
+        if not csvs:
+            raise FileNotFoundError(f"No CSV files found inside directory {path}")
+        return csvs
+    if path.suffix.lower() != ".csv":
+        raise ValueError("--data-path must point to a CSV file or directory containing CSV files")
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return [path]
+
+
+def _load_training_frame(paths: Iterable[Path]) -> pd.DataFrame:
+    paths = list(paths)
+    if len(paths) == 1:
+        frame = pd.read_csv(paths[0])
+        if "symbol" not in frame.columns:
+            frame["symbol"] = paths[0].stem.split("_")[0].upper()
+    else:
+        frame = load_universe_dataframe(paths)
+        return frame
+
+    if "datetime" not in frame.columns:
+        raise ValueError("Dataset must include a 'datetime' column")
+    frame["datetime"] = pd.to_datetime(frame["datetime"], utc=True, errors="coerce")
+    frame = frame.dropna(subset=["datetime"] + CANDLESTICK_COLUMNS)
+    frame["symbol"] = frame["symbol"].astype(str).str.upper()
+    frame = frame.sort_values(["symbol", "datetime"]).reset_index(drop=True)
+    return frame
+
+
+def main() -> None:
+    args = parse_args()
+    configure_logging()
+    data_path = args.data_path
+    device = resolve_device(args.device)
+    if device.type == "cpu" and args.batch_size > 64:
+        print("Reducing batch size to 64 for CPU-only training.")
+        args.batch_size = 64
+    mixed_precision = args.mixed_precision and device.type == "cuda"
+    config = build_config(args, data_path)
+    config.trainer.batch_size = args.batch_size
+    seed_everything(config.trainer.seed)
+
+    csv_paths = _discover_csv_files(config.dataset.data_path)
+    frame = _load_training_frame(csv_paths)
+    group_column = "symbol" if "symbol" in frame.columns else None
+    print(
+        f"Loaded dataset with {len(frame)} rows"
+        + (f" across {frame['symbol'].nunique()} symbols" if group_column else "")
+    )
+
+    train_frame, val_frame = split_train_validation(
+        frame, config.dataset.train_ratio, group_column=group_column
+    )
+
+    window = SequenceWindow(
+        input_window=config.dataset.input_window,
+        horizon=config.dataset.horizon,
+        stride=config.dataset.stride,
+    )
+
+    train_dataset = CandlestickDataset(
+        train_frame,
+        window,
+        normalize=config.dataset.normalize,
+        group_column=group_column,
+    )
+    stats = None
+    if train_dataset.normalize:
+        stats = NormalizationStats(mean=train_dataset.mean, std=train_dataset.std)
+    val_dataset = CandlestickDataset(
+        val_frame,
+        window,
+        normalize=config.dataset.normalize,
+        stats=stats,
+        group_column=group_column,
+    )
+
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=config.trainer.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        pin_memory=device.type == "cuda",
+        drop_last=True,
+    )
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=config.trainer.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        pin_memory=device.type == "cuda",
+        drop_last=False,
+    )
+
+    model_config = TransformerConfig(
+        input_dim=len(train_dataset.feature_columns),
+        d_model=args.d_model,
+        nhead=args.nhead,
+        num_layers=args.num_layers,
+        dim_feedforward=args.ff_dim,
+        dropout=args.dropout,
+        horizon=config.dataset.horizon,
+    )
+    model = TemporalTransformer(model_config)
+
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=config.optimizer.lr,
+        weight_decay=config.optimizer.weight_decay,
+        betas=config.optimizer.betas,
+    )
+    scheduler = CosineAnnealingLR(
+        optimizer,
+        T_max=config.trainer.epochs,
+        eta_min=config.optimizer.lr * 0.1,
+    )
+
+    output_dir = ensure_dir(config.trainer.output_dir)
+    checkpoints_dir = ensure_dir(output_dir / "checkpoints")
+    logs_dir = ensure_dir(output_dir / "logs")
+
+    callbacks = [
+        HistoryTracker(),
+        JSONLLogger(logs_dir / "training_log.jsonl"),
+        ModelCheckpoint(directory=checkpoints_dir, save_every=config.trainer.checkpoint_interval),
+        EarlyStopping(patience=config.trainer.early_stopping_patience),
+    ]
+
+    normalization_payload = None
+    if stats:
+        normalization_payload = {
+            "mean": stats.mean.to_dict(),
+            "std": stats.std.to_dict(),
+            "feature_columns": train_dataset.feature_columns,
+        }
+
+    trainer = Trainer(
+        model=model,
+        optimizer=optimizer,
+        scheduler=scheduler,
+        device=device,
+        mixed_precision=mixed_precision,
+        max_grad_norm=config.trainer.max_grad_norm,
+        gradient_accumulation=config.trainer.gradient_accumulation,
+        callbacks=callbacks,
+        extra_state=normalization_payload,
+    )
+
+    hyperparams = {
+        "dataset": config.dataset.__dict__,
+        "model": model_config.__dict__,
+        "optimizer": config.optimizer.__dict__,
+        "trainer": config.trainer.__dict__,
+    }
+    log_hyperparameters(hyperparams)
+    with (output_dir / "hparams.json").open("w", encoding="utf-8") as fp:
+        json.dump(hyperparams, fp, indent=2, default=str)
+
+    start_epoch = 0
+    if args.resume:
+        checkpoint = torch.load(args.resume, map_location=device)
+        model.load_state_dict(checkpoint["model_state_dict"])
+        if "optimizer_state_dict" in checkpoint:
+            optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        if "scheduler_state_dict" in checkpoint and scheduler is not None:
+            scheduler.load_state_dict(checkpoint["scheduler_state_dict"])
+        if checkpoint.get("extra"):
+            normalization_payload = checkpoint["extra"]
+            trainer.extra_state.update(normalization_payload)
+        start_epoch = checkpoint.get("epoch", 0)
+        print(f"Resuming training from epoch {start_epoch}")
+
+    trainer.train(
+        train_loader,
+        epochs=config.trainer.epochs,
+        validation_loader=val_loader,
+        start_epoch=start_epoch,
+    )
+
+    final_path = output_dir / "final_model.pt"
+    artifact = {
+        "model_state_dict": model.state_dict(),
+        "optimizer_state_dict": optimizer.state_dict(),
+        "scheduler_state_dict": scheduler.state_dict(),
+        "model_config": model_config.__dict__,
+        "normalization": normalization_payload,
+    }
+    torch.save(artifact, final_path)
+    if normalization_payload:
+        with (output_dir / "normalization.json").open("w", encoding="utf-8") as fp:
+            json.dump(normalization_payload, fp, indent=2)
+    print(f"Training complete. Model saved to {final_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/stonkex/__init__.py
+++ b/stonkex/__init__.py
@@ -1,0 +1,11 @@
+"""StonkEx package initialization."""
+__all__ = [
+    "config",
+    "data",
+    "inference",
+    "models",
+    "training",
+    "visualization",
+]
+
+__version__ = "0.1.0"

--- a/stonkex/config.py
+++ b/stonkex/config.py
@@ -1,0 +1,55 @@
+"""Project-wide configuration dataclasses."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from stonkex.models.transformer import TransformerConfig
+
+
+@dataclass
+class DatasetConfig:
+    data_path: Path
+    input_window: int = 96
+    horizon: int = 12
+    stride: int = 1
+    train_ratio: float = 0.8
+    normalize: bool = True
+
+
+@dataclass
+class OptimizerConfig:
+    lr: float = 1e-4
+    weight_decay: float = 1e-2
+    betas: tuple[float, float] = (0.9, 0.999)
+
+
+@dataclass
+class SchedulerConfig:
+    warmup_steps: int = 500
+    max_lr: float = 3e-4
+    final_lr: float = 1e-5
+
+
+@dataclass
+class TrainerConfig:
+    epochs: int = 100
+    batch_size: int = 256
+    gradient_accumulation: int = 1
+    mixed_precision: bool = True
+    max_grad_norm: float = 1.0
+    log_every: int = 10
+    validation_interval: int = 1
+    early_stopping_patience: int = 12
+    output_dir: Path = field(default_factory=lambda: Path("artifacts"))
+    checkpoint_interval: int = 1
+    seed: int = 42
+
+
+@dataclass
+class ExperimentConfig:
+    dataset: DatasetConfig
+    model: TransformerConfig
+    optimizer: OptimizerConfig = field(default_factory=OptimizerConfig)
+    scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
+    trainer: TrainerConfig = field(default_factory=TrainerConfig)

--- a/stonkex/data/__init__.py
+++ b/stonkex/data/__init__.py
@@ -1,0 +1,36 @@
+"""Data loading and preprocessing utilities for StonkEx."""
+
+from .datasets import (
+    CANDLESTICK_COLUMNS,
+    CandlestickDataset,
+    NormalizationStats,
+    SequenceWindow,
+    ensure_datetime_index,
+    split_train_validation,
+)
+from .preprocessing import DataDownloadConfig, download_candles, resample_timeframe, save_dataframe
+from .universe import (
+    DEFAULT_SYMBOLS,
+    UniverseBuildResult,
+    download_symbol_universe,
+    load_symbol_universe,
+    load_universe_dataframe,
+)
+
+__all__ = [
+    "CANDLESTICK_COLUMNS",
+    "CandlestickDataset",
+    "NormalizationStats",
+    "SequenceWindow",
+    "ensure_datetime_index",
+    "split_train_validation",
+    "DataDownloadConfig",
+    "download_candles",
+    "resample_timeframe",
+    "save_dataframe",
+    "DEFAULT_SYMBOLS",
+    "UniverseBuildResult",
+    "download_symbol_universe",
+    "load_symbol_universe",
+    "load_universe_dataframe",
+]

--- a/stonkex/data/datasets.py
+++ b/stonkex/data/datasets.py
@@ -1,0 +1,182 @@
+"""Dataset primitives for candlestick forecasting."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+import numpy as np
+import pandas as pd
+import torch
+from torch.utils.data import Dataset
+
+CANDLESTICK_COLUMNS: List[str] = ["open", "high", "low", "close", "volume"]
+TARGET_COLUMN = "close"
+
+
+@dataclass(frozen=True)
+class SequenceWindow:
+    """Defines the sliding window used to generate training samples."""
+
+    input_window: int
+    horizon: int
+    stride: int = 1
+
+    def __post_init__(self) -> None:
+        if self.input_window <= 0:
+            raise ValueError("input_window must be positive")
+        if self.horizon <= 0:
+            raise ValueError("horizon must be positive")
+        if self.stride <= 0:
+            raise ValueError("stride must be positive")
+
+    @property
+    def total_window(self) -> int:
+        return self.input_window + self.horizon
+
+
+@dataclass
+class NormalizationStats:
+    """Stores normalization parameters shared between datasets."""
+
+    mean: pd.Series
+    std: pd.Series
+
+    @classmethod
+    def from_frame(cls, frame: pd.DataFrame, feature_columns: Iterable[str]) -> "NormalizationStats":
+        mean = frame.loc[:, feature_columns].mean()
+        std = frame.loc[:, feature_columns].std().replace(0, 1.0)
+        std = std.replace({0.0: 1.0})
+        return cls(mean=mean, std=std)
+
+
+def ensure_datetime_index(frame: pd.DataFrame) -> pd.DataFrame:
+    """Return a dataframe indexed by datetime for consistent ordering."""
+
+    if "datetime" in frame.columns:
+        frame = frame.copy()
+        frame["datetime"] = pd.to_datetime(frame["datetime"], utc=True, errors="coerce")
+        frame = frame.dropna(subset=["datetime"]).sort_values("datetime")
+        frame = frame.set_index("datetime")
+    elif not isinstance(frame.index, pd.DatetimeIndex):
+        raise ValueError("DataFrame must contain a 'datetime' column or be indexed by DatetimeIndex")
+    else:
+        frame = frame.sort_index()
+    return frame
+
+
+def split_train_validation(
+    frame: pd.DataFrame, train_ratio: float = 0.8, group_column: Optional[str] = None
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Split a dataframe into train/validation partitions preserving order."""
+
+    if not 0 < train_ratio < 1:
+        raise ValueError("train_ratio must be between 0 and 1")
+
+    if group_column and group_column in frame.columns:
+        train_parts: list[pd.DataFrame] = []
+        val_parts: list[pd.DataFrame] = []
+        for _, group in frame.groupby(group_column, sort=False):
+            if len(group) < 2:
+                continue
+            cutoff = int(len(group) * train_ratio)
+            cutoff = min(max(cutoff, 1), len(group) - 1)
+            train_parts.append(group.iloc[:cutoff])
+            val_parts.append(group.iloc[cutoff:])
+        if not val_parts:
+            raise ValueError(
+                "Validation split is empty; provide more data or adjust train_ratio/grouping"
+            )
+        train = pd.concat(train_parts, ignore_index=True)
+        val = pd.concat(val_parts, ignore_index=True)
+        return train.reset_index(drop=True), val.reset_index(drop=True)
+
+    cutoff = int(len(frame) * train_ratio)
+    cutoff = max(cutoff, 1)
+    train = frame.iloc[:cutoff].reset_index(drop=True)
+    val = frame.iloc[cutoff:].reset_index(drop=True)
+    if val.empty:
+        raise ValueError("Validation split is empty; provide more data or adjust train_ratio")
+    return train, val
+
+
+class CandlestickDataset(Dataset):
+    """PyTorch dataset that yields normalized candlestick windows."""
+
+    def __init__(
+        self,
+        frame: pd.DataFrame,
+        window: SequenceWindow,
+        normalize: bool = True,
+        stats: Optional[NormalizationStats] = None,
+        feature_columns: Optional[Iterable[str]] = None,
+        group_column: Optional[str] = None,
+    ) -> None:
+        if len(frame) < window.total_window:
+            raise ValueError("Dataframe is too small for the requested window and horizon")
+        self.window = window
+        self.feature_columns = list(feature_columns or CANDLESTICK_COLUMNS)
+        missing = [col for col in self.feature_columns if col not in frame.columns]
+        if missing:
+            raise ValueError(f"Missing required columns: {missing}")
+        self.group_column = group_column
+        self._frame = frame.reset_index(drop=True).copy()
+
+        if self.group_column:
+            if self.group_column not in self._frame.columns:
+                raise ValueError(f"group_column '{self.group_column}' not found in dataframe")
+            if "datetime" in self._frame.columns:
+                self._frame["datetime"] = pd.to_datetime(
+                    self._frame["datetime"], utc=True, errors="coerce"
+                )
+                self._frame = self._frame.dropna(subset=["datetime"])
+                self._frame = self._frame.sort_values([self.group_column, "datetime"]).reset_index(
+                    drop=True
+                )
+            else:
+                self._frame = self._frame.sort_values(self.group_column).reset_index(drop=True)
+
+        if stats is None:
+            stats = NormalizationStats.from_frame(self._frame, self.feature_columns)
+        else:
+            mean = stats.mean.reindex(self.feature_columns)
+            std = stats.std.reindex(self.feature_columns).replace({0.0: 1.0})
+            stats = NormalizationStats(mean=mean, std=std)
+
+        self.mean = stats.mean
+        self.std = stats.std
+
+        features = self._frame.loc[:, self.feature_columns].astype(np.float32)
+        if normalize:
+            normalized = (features - self.mean) / self.std
+        else:
+            normalized = features
+        self.inputs = normalized.to_numpy(dtype=np.float32)
+        self.targets = self._frame[TARGET_COLUMN].to_numpy(dtype=np.float32)
+
+        self.normalize = normalize
+        self.stats = stats
+        if self.group_column:
+            self.indices: list[int] = []
+            for _, group in self._frame.groupby(self.group_column, sort=False):
+                if len(group) < window.total_window:
+                    continue
+                start_idx = int(group.index.min())
+                last_start = int(group.index.max()) - window.total_window + 1
+                for start in range(start_idx, last_start + 1, window.stride):
+                    self.indices.append(start)
+        else:
+            self.indices = list(range(0, len(self._frame) - window.total_window + 1, window.stride))
+
+        if not self.indices:
+            raise ValueError("No windows available for the given configuration")
+
+    def __len__(self) -> int:
+        return len(self.indices)
+
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
+        start = self.indices[idx]
+        input_end = start + self.window.input_window
+        target_end = input_end + self.window.horizon
+        inputs = self.inputs[start:input_end]
+        targets = self.targets[input_end:target_end]
+        return torch.from_numpy(inputs), torch.from_numpy(targets)

--- a/stonkex/data/preprocessing.py
+++ b/stonkex/data/preprocessing.py
@@ -1,0 +1,91 @@
+"""Data download and preprocessing helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from .datasets import CANDLESTICK_COLUMNS, ensure_datetime_index
+
+
+@dataclass
+class DataDownloadConfig:
+    """Configuration for downloading OHLCV candles via yfinance."""
+
+    symbol: str
+    start: str
+    end: str
+    interval: str = "1h"
+    auto_adjust: bool = True
+
+
+def download_candles(config: DataDownloadConfig) -> pd.DataFrame:
+    """Download OHLCV candles using yfinance."""
+
+    try:
+        import yfinance as yf
+    except ImportError as exc:  # pragma: no cover - exercised in runtime environments
+        raise RuntimeError("yfinance is required to download market data") from exc
+
+    data = yf.download(
+        tickers=config.symbol,
+        start=config.start,
+        end=config.end,
+        interval=config.interval,
+        auto_adjust=config.auto_adjust,
+        progress=False,
+        threads=False,
+    )
+    if data.empty:
+        raise ValueError("No data returned for the given symbol/timeframe")
+
+    frame = data.rename(
+        columns={
+            "Open": "open",
+            "High": "high",
+            "Low": "low",
+            "Close": "close",
+            "Adj Close": "close",
+            "Volume": "volume",
+        }
+    ).reset_index()
+
+    datetime_col = next((col for col in ("Datetime", "Date", "datetime") if col in frame.columns), None)
+    if datetime_col is None:
+        raise ValueError("Downloaded data does not contain a datetime column")
+    frame = frame.rename(columns={datetime_col: "datetime"})
+    frame["datetime"] = pd.to_datetime(frame["datetime"], utc=True)
+
+    for column in CANDLESTICK_COLUMNS:
+        if column not in frame.columns:
+            frame[column] = pd.NA
+    frame = frame.loc[:, ["datetime", *CANDLESTICK_COLUMNS]].dropna()
+    frame["symbol"] = config.symbol
+    return frame
+
+
+def resample_timeframe(frame: pd.DataFrame, rule: str) -> pd.DataFrame:
+    """Resample an OHLCV dataframe to a coarser timeframe."""
+
+    indexed = ensure_datetime_index(frame)
+    aggregated = indexed.resample(rule).agg(
+        {
+            "open": "first",
+            "high": "max",
+            "low": "min",
+            "close": "last",
+            "volume": "sum",
+        }
+    ).dropna()
+    aggregated = aggregated.reset_index()
+    aggregated.rename(columns={"datetime": "datetime"}, inplace=True)
+    return aggregated
+
+
+def save_dataframe(frame: pd.DataFrame, output: Path, float_precision: Optional[int] = 6) -> None:
+    """Persist a dataframe to disk as CSV, creating parent directories as needed."""
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_csv(output, index=False, float_format=f"%.{float_precision}f" if float_precision else None)

--- a/stonkex/data/universe.py
+++ b/stonkex/data/universe.py
@@ -1,0 +1,200 @@
+"""Helpers to build multi-symbol candlestick datasets."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+import pandas as pd
+
+from .datasets import CANDLESTICK_COLUMNS
+from .preprocessing import DataDownloadConfig, download_candles, resample_timeframe, save_dataframe
+
+
+# 70 heavily traded US equities across multiple sectors.
+DEFAULT_SYMBOLS: List[str] = [
+    "AAPL",
+    "MSFT",
+    "GOOGL",
+    "AMZN",
+    "META",
+    "TSLA",
+    "NVDA",
+    "JPM",
+    "V",
+    "MA",
+    "HD",
+    "DIS",
+    "NFLX",
+    "KO",
+    "PEP",
+    "PFE",
+    "MRK",
+    "UNH",
+    "VZ",
+    "T",
+    "INTC",
+    "AMD",
+    "CSCO",
+    "ADBE",
+    "CRM",
+    "ORCL",
+    "IBM",
+    "QCOM",
+    "TXN",
+    "AVGO",
+    "BA",
+    "LMT",
+    "CAT",
+    "GE",
+    "HON",
+    "MMM",
+    "UPS",
+    "FDX",
+    "NKE",
+    "MCD",
+    "SBUX",
+    "COST",
+    "WMT",
+    "LOW",
+    "TGT",
+    "CVS",
+    "WBA",
+    "XOM",
+    "CVX",
+    "SLB",
+    "COP",
+    "OXY",
+    "SPG",
+    "PLD",
+    "AMT",
+    "NEE",
+    "DUK",
+    "SO",
+    "D",
+    "AEP",
+    "BK",
+    "GS",
+    "MS",
+    "AXP",
+    "C",
+    "TFC",
+    "USB",
+    "SCHW",
+    "BLK",
+]
+
+
+@dataclass
+class UniverseBuildResult:
+    """Summary of the downloaded universe."""
+
+    symbols: list[str]
+    paths: list[Path]
+    total_rows: int
+    total_bytes: int
+
+
+def load_symbol_universe(
+    symbols: Optional[Sequence[str]] = None, *, symbols_file: Optional[Path] = None, min_symbols: int = 1
+) -> list[str]:
+    """Return a unique, upper-case list of ticker symbols to download."""
+
+    collected: list[str] = []
+    if symbols_file:
+        if not symbols_file.exists():
+            raise FileNotFoundError(symbols_file)
+        with symbols_file.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                token = line.strip()
+                if token:
+                    collected.append(token)
+    if symbols:
+        collected.extend(symbols)
+    if not collected:
+        collected = DEFAULT_SYMBOLS.copy()
+    cleaned = []
+    seen = set()
+    for symbol in collected:
+        upper = symbol.strip().upper()
+        if not upper:
+            continue
+        if upper in seen:
+            continue
+        seen.add(upper)
+        cleaned.append(upper)
+    if len(cleaned) < min_symbols:
+        raise ValueError(
+            f"Requested universe has {len(cleaned)} symbols which is below the required minimum of {min_symbols}"
+        )
+    return cleaned
+
+
+def download_symbol_universe(
+    symbols: Sequence[str],
+    *,
+    start: str,
+    end: str,
+    interval: str,
+    output_dir: Path,
+    resample: Optional[str] = None,
+    float_precision: Optional[int] = 6,
+    max_bytes: int = 1024 ** 3,
+    resume: bool = True,
+) -> UniverseBuildResult:
+    """Download OHLCV candles for many symbols ensuring the dataset stays within the byte budget."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    saved_paths: list[Path] = []
+    total_bytes = 0
+    total_rows = 0
+
+    for symbol in symbols:
+        target_path = output_dir / f"{symbol}_{interval}.csv"
+        if resume and target_path.exists():
+            size = target_path.stat().st_size
+            total_bytes += size
+            saved_paths.append(target_path)
+            df = pd.read_csv(target_path)
+            total_rows += len(df)
+            continue
+
+        config = DataDownloadConfig(symbol=symbol, start=start, end=end, interval=interval)
+        frame = download_candles(config)
+        if resample:
+            frame = resample_timeframe(frame, resample)
+        frame["symbol"] = symbol
+        save_dataframe(frame, target_path, float_precision=float_precision)
+        size = target_path.stat().st_size
+        total_bytes += size
+        total_rows += len(frame)
+        if total_bytes > max_bytes:
+            raise RuntimeError(
+                f"Aborting download – combined CSV size {total_bytes} bytes exceeds the configured limit of {max_bytes} bytes"
+            )
+        saved_paths.append(target_path)
+
+    return UniverseBuildResult(symbols=list(symbols), paths=saved_paths, total_rows=total_rows, total_bytes=total_bytes)
+
+
+def load_universe_dataframe(paths: Iterable[Path]) -> pd.DataFrame:
+    """Load a collection of CSV files into a single sorted dataframe."""
+
+    frames: list[pd.DataFrame] = []
+    for path in paths:
+        frame = pd.read_csv(path)
+        if "symbol" not in frame.columns:
+            frame["symbol"] = path.stem.split("_")[0].upper()
+        missing = [col for col in ("datetime", *CANDLESTICK_COLUMNS) if col not in frame.columns]
+        if missing:
+            raise ValueError(f"File {path} is missing columns: {missing}")
+        frame["datetime"] = pd.to_datetime(frame["datetime"], utc=True, errors="coerce")
+        frame = frame.dropna(subset=["datetime"])
+        frames.append(frame)
+    if not frames:
+        raise ValueError("No CSV files provided to load_universe_dataframe")
+    combined = pd.concat(frames, ignore_index=True)
+    combined["symbol"] = combined["symbol"].astype(str).str.upper()
+    combined = combined.dropna(subset=CANDLESTICK_COLUMNS)
+    combined = combined.sort_values(["symbol", "datetime"]).reset_index(drop=True)
+    return combined

--- a/stonkex/inference/__init__.py
+++ b/stonkex/inference/__init__.py
@@ -1,0 +1,4 @@
+"""Inference helpers exports."""
+from .predictor import Predictor, PredictorConfig
+
+__all__ = ["Predictor", "PredictorConfig"]

--- a/stonkex/inference/predictor.py
+++ b/stonkex/inference/predictor.py
@@ -1,0 +1,32 @@
+"""Model loading and inference utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import torch
+
+from stonkex.models.transformer import TemporalTransformer, TransformerConfig
+
+
+@dataclass
+class PredictorConfig:
+    model_path: Path
+    device: str = "cuda"
+
+
+class Predictor:
+    def __init__(self, config: PredictorConfig, model_config: TransformerConfig) -> None:
+        device = torch.device(config.device if torch.cuda.is_available() else "cpu")
+        self.model = TemporalTransformer(model_config)
+        self.model.load_state_dict(torch.load(config.model_path, map_location=device))
+        self.model.to(device)
+        self.model.eval()
+        self.device = device
+
+    @torch.no_grad()
+    def predict(self, inputs: torch.Tensor) -> torch.Tensor:
+        inputs = inputs.to(self.device)
+        outputs = self.model(inputs)
+        return outputs.cpu()

--- a/stonkex/models/__init__.py
+++ b/stonkex/models/__init__.py
@@ -1,0 +1,4 @@
+"""Model exports."""
+from .transformer import TemporalTransformer, TransformerConfig
+
+__all__ = ["TemporalTransformer", "TransformerConfig"]

--- a/stonkex/models/transformer.py
+++ b/stonkex/models/transformer.py
@@ -1,0 +1,70 @@
+"""Transformer-based forecaster optimized for GPU training."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+
+
+@dataclass
+class TransformerConfig:
+    input_dim: int
+    d_model: int = 256
+    nhead: int = 8
+    num_layers: int = 4
+    dim_feedforward: int = 512
+    dropout: float = 0.1
+    activation: str = "gelu"
+    horizon: int = 12
+
+
+class PositionalEncoding(nn.Module):
+    def __init__(self, d_model: int, dropout: float = 0.1, max_len: int = 1000) -> None:
+        super().__init__()
+        self.dropout = nn.Dropout(p=dropout)
+
+        position = torch.arange(0, max_len).unsqueeze(1)
+        div_term = torch.exp(torch.arange(0, d_model, 2) * (-torch.log(torch.tensor(10000.0)) / d_model))
+        pe = torch.zeros(max_len, d_model)
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)
+        self.register_buffer("pe", pe)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - simple
+        x = x + self.pe[:, : x.size(1)]
+        return self.dropout(x)
+
+
+class TemporalTransformer(nn.Module):
+    def __init__(self, config: TransformerConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.input_projection = nn.Linear(config.input_dim, config.d_model)
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=config.d_model,
+            nhead=config.nhead,
+            dim_feedforward=config.dim_feedforward,
+            dropout=config.dropout,
+            activation=config.activation,
+            batch_first=True,
+            norm_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=config.num_layers)
+        self.positional_encoding = PositionalEncoding(config.d_model, dropout=config.dropout)
+        self.head = nn.Sequential(
+            nn.LayerNorm(config.d_model),
+            nn.Linear(config.d_model, config.d_model // 2),
+            nn.GELU(),
+            nn.Dropout(config.dropout),
+            nn.Linear(config.d_model // 2, config.horizon),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x shape: (batch, seq_len, input_dim)
+        x = self.input_projection(x)
+        x = self.positional_encoding(x)
+        encoded = self.encoder(x)
+        pooled = encoded[:, -1, :]
+        return self.head(pooled)

--- a/stonkex/training/__init__.py
+++ b/stonkex/training/__init__.py
@@ -1,0 +1,16 @@
+"""Training package exports."""
+from .callbacks import CallbackState, EarlyStopping, HistoryTracker, JSONLLogger, ModelCheckpoint
+from .trainer import Trainer
+from .utils import configure_logging, get_device, seed_everything
+
+__all__ = [
+    "CallbackState",
+    "EarlyStopping",
+    "HistoryTracker",
+    "JSONLLogger",
+    "ModelCheckpoint",
+    "Trainer",
+    "configure_logging",
+    "get_device",
+    "seed_everything",
+]

--- a/stonkex/training/callbacks.py
+++ b/stonkex/training/callbacks.py
@@ -1,0 +1,148 @@
+"""Callback implementations for training instrumentation."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+
+LOGGER = logging.getLogger("stonkex.callbacks")
+
+
+@dataclass
+class CallbackState:
+    epoch: int
+    step: int
+    train_loss: float
+    val_loss: Optional[float]
+    model_state_dict: Dict[str, torch.Tensor]
+    optimizer_state_dict: Optional[Dict[str, Any]] = None
+    scheduler_state_dict: Optional[Dict[str, Any]] = None
+    extra: Optional[Dict[str, Any]] = None
+
+
+class TrainingCallback:
+    def on_train_begin(self, **_: Any) -> None:  # pragma: no cover - base hook
+        pass
+
+    def on_epoch_end(self, state: CallbackState) -> None:  # pragma: no cover - base hook
+        pass
+
+    def on_train_end(self, **_: Any) -> None:  # pragma: no cover - base hook
+        pass
+
+
+@dataclass
+class HistoryTracker(TrainingCallback):
+    history: List[CallbackState] = field(default_factory=list)
+
+    def on_epoch_end(self, state: CallbackState) -> None:
+        shallow = CallbackState(
+            epoch=state.epoch,
+            step=state.step,
+            train_loss=state.train_loss,
+            val_loss=state.val_loss,
+            model_state_dict={},
+            optimizer_state_dict=None,
+            scheduler_state_dict=None,
+            extra=None,
+        )
+        self.history.append(shallow)
+
+    def to_pandas(self):  # pragma: no cover - optional import
+        try:
+            import pandas as pd
+        except Exception as exc:  # pragma: no cover
+            raise RuntimeError("pandas must be installed to export history") from exc
+        return pd.DataFrame([s.__dict__ for s in self.history])
+
+
+@dataclass
+class JSONLLogger(TrainingCallback):
+    path: Path
+
+    def __post_init__(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.file = self.path.open("w", encoding="utf-8")
+
+    def on_epoch_end(self, state: CallbackState) -> None:
+        payload = {
+            "epoch": state.epoch,
+            "step": state.step,
+            "train_loss": state.train_loss,
+            "val_loss": state.val_loss,
+        }
+        self.file.write(json.dumps(payload) + "\n")
+        self.file.flush()
+
+    def on_train_end(self, **_: Any) -> None:
+        self.file.close()
+
+
+@dataclass
+class ModelCheckpoint(TrainingCallback):
+    directory: Path
+    monitor: str = "val_loss"
+    mode: str = "min"
+    save_every: int = 1
+
+    def __post_init__(self) -> None:
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self.best_score = np.inf if self.mode == "min" else -np.inf
+
+    def should_save(self, value: Optional[float]) -> bool:
+        if value is None:
+            return False
+        if self.mode == "min":
+            return value < self.best_score
+        return value > self.best_score
+
+    def on_epoch_end(self, state: CallbackState) -> None:
+        if state.epoch % self.save_every != 0:
+            return
+        value = getattr(state, self.monitor, None)
+        if self.should_save(value):
+            self.best_score = value  # type: ignore[assignment]
+            path = self.directory / f"epoch_{state.epoch:04d}.pt"
+            torch.save(
+                {
+                    "epoch": state.epoch,
+                    "model_state_dict": state.model_state_dict,
+                    "optimizer_state_dict": state.optimizer_state_dict,
+                    "scheduler_state_dict": state.scheduler_state_dict,
+                    "train_loss": state.train_loss,
+                    "val_loss": state.val_loss,
+                    "extra": state.extra,
+                },
+                path,
+            )
+            LOGGER.info("Saved checkpoint to %s (score=%s)", path, value)
+
+
+@dataclass
+class EarlyStopping(TrainingCallback):
+    patience: int = 10
+    min_delta: float = 0.0
+    monitor: str = "val_loss"
+
+    def __post_init__(self) -> None:
+        self.best = np.inf
+        self.counter = 0
+        self.should_stop = False
+
+    def on_epoch_end(self, state: CallbackState) -> None:
+        value = getattr(state, self.monitor, None)
+        if value is None:
+            return
+        if value < self.best - self.min_delta:
+            self.best = value
+            self.counter = 0
+        else:
+            self.counter += 1
+            if self.counter >= self.patience:
+                self.should_stop = True
+                LOGGER.info("Early stopping triggered at epoch %s", state.epoch)

--- a/stonkex/training/trainer.py
+++ b/stonkex/training/trainer.py
@@ -1,0 +1,132 @@
+"""High-level training loop optimized for RTX 4080 / i9 platforms."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+import torch
+from torch import nn
+from torch.cuda import amp
+from torch.utils.data import DataLoader
+
+from stonkex.training.callbacks import (
+    CallbackState,
+    EarlyStopping,
+    JSONLLogger,
+    ModelCheckpoint,
+    TrainingCallback,
+)
+from stonkex.training.utils import LOGGER, count_parameters
+
+
+class Trainer:
+    def __init__(
+        self,
+        model: nn.Module,
+        optimizer: torch.optim.Optimizer,
+        scheduler: Optional[torch.optim.lr_scheduler._LRScheduler],
+        device: torch.device,
+        mixed_precision: bool = True,
+        max_grad_norm: float = 1.0,
+        gradient_accumulation: int = 1,
+        callbacks: Optional[List[TrainingCallback]] = None,
+        extra_state: Optional[dict] = None,
+    ) -> None:
+        self.model = model.to(device)
+        self.optimizer = optimizer
+        self.scheduler = scheduler
+        self.device = device
+        self.mixed_precision = mixed_precision and torch.cuda.is_available()
+        self.scaler = amp.GradScaler(enabled=self.mixed_precision)
+        self.max_grad_norm = max_grad_norm
+        self.gradient_accumulation = max(1, gradient_accumulation)
+        self.callbacks = callbacks or []
+        self.extra_state = extra_state or {}
+        LOGGER.info("Model parameters: %s", count_parameters(model))
+
+    def _move_batch(self, batch):
+        inputs, targets = batch
+        return inputs.to(self.device), targets.to(self.device)
+
+    def train(
+        self,
+        train_loader: DataLoader,
+        epochs: int,
+        validation_loader: Optional[DataLoader] = None,
+        start_epoch: int = 0,
+    ) -> None:
+        global_step = start_epoch * len(train_loader)
+        for callback in self.callbacks:
+            callback.on_train_begin()
+
+        early_stopping = next((c for c in self.callbacks if isinstance(c, EarlyStopping)), None)
+
+        for epoch in range(start_epoch + 1, epochs + 1):
+            self.model.train()
+            running_loss = 0.0
+            self.optimizer.zero_grad(set_to_none=True)
+
+            for step, batch in enumerate(train_loader, start=1):
+                inputs, targets = self._move_batch(batch)
+                with amp.autocast(enabled=self.mixed_precision):
+                    outputs = self.model(inputs)
+                    loss = nn.functional.mse_loss(outputs, targets)
+                    loss = loss / self.gradient_accumulation
+                self.scaler.scale(loss).backward()
+
+                if step % self.gradient_accumulation == 0:
+                    if self.max_grad_norm:
+                        self.scaler.unscale_(self.optimizer)
+                        torch.nn.utils.clip_grad_norm_(
+                            self.model.parameters(), self.max_grad_norm
+                        )
+                    self.scaler.step(self.optimizer)
+                    self.scaler.update()
+                    self.optimizer.zero_grad(set_to_none=True)
+                    if self.scheduler is not None:
+                        self.scheduler.step()
+                running_loss += loss.item() * self.gradient_accumulation
+                global_step += 1
+
+            train_loss = running_loss / len(train_loader)
+            val_loss = None
+            if validation_loader is not None:
+                val_loss = self.evaluate(validation_loader)
+
+            state = CallbackState(
+                epoch=epoch,
+                step=global_step,
+                train_loss=train_loss,
+                val_loss=val_loss,
+                model_state_dict=self.model.state_dict(),
+                optimizer_state_dict=self.optimizer.state_dict(),
+                scheduler_state_dict=self.scheduler.state_dict() if self.scheduler else None,
+                extra=self.extra_state,
+            )
+            for callback in self.callbacks:
+                callback.on_epoch_end(state)
+
+            LOGGER.info(
+                "Epoch %d | train_loss=%.6f | val_loss=%s",
+                epoch,
+                train_loss,
+                f"{val_loss:.6f}" if val_loss is not None else "-",
+            )
+
+            if early_stopping and early_stopping.should_stop:
+                LOGGER.info("Stopping training due to early stopping criterion")
+                break
+
+        for callback in self.callbacks:
+            callback.on_train_end()
+
+    @torch.no_grad()
+    def evaluate(self, loader: DataLoader) -> float:
+        self.model.eval()
+        loss_sum = 0.0
+        for batch in loader:
+            inputs, targets = self._move_batch(batch)
+            with amp.autocast(enabled=self.mixed_precision):
+                outputs = self.model(inputs)
+                loss = nn.functional.mse_loss(outputs, targets)
+            loss_sum += loss.item()
+        return loss_sum / len(loader)

--- a/stonkex/training/utils.py
+++ b/stonkex/training/utils.py
@@ -1,0 +1,69 @@
+"""Utility helpers for the training loop."""
+from __future__ import annotations
+
+import logging
+import os
+import random
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+import torch
+
+
+LOGGER = logging.getLogger("stonkex")
+
+
+def configure_logging(log_level: int = logging.INFO) -> None:
+    env_level = os.getenv("STONKEX_LOG_LEVEL")
+    if env_level:
+        log_level = getattr(logging, env_level.upper(), log_level)
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+
+
+def seed_everything(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def get_device(prefer_gpu: bool = True) -> torch.device:
+    if prefer_gpu and torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+def resolve_device(choice: str = "auto") -> torch.device:
+    """Resolve a user-provided device string to a torch.device."""
+
+    normalized = choice.lower()
+    if normalized == "cpu":
+        return torch.device("cpu")
+    if normalized == "cuda":
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA was requested but is not available on this host")
+        return torch.device("cuda")
+    return get_device(prefer_gpu=True)
+
+
+def ensure_dir(path: str | Path) -> Path:
+    path = Path(path)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def count_parameters(model: torch.nn.Module) -> int:
+    return sum(p.numel() for p in model.parameters() if p.requires_grad)
+
+
+def tensor_to_numpy(tensor: torch.Tensor) -> np.ndarray:
+    return tensor.detach().cpu().numpy()
+
+
+def log_hyperparameters(params: Dict[str, Any]) -> None:
+    LOGGER.info("Training hyperparameters: %s", params)

--- a/stonkex/visualization/__init__.py
+++ b/stonkex/visualization/__init__.py
@@ -1,0 +1,4 @@
+"""Visualization exports."""
+from .chart import candlestick_chart
+
+__all__ = ["candlestick_chart"]

--- a/stonkex/visualization/chart.py
+++ b/stonkex/visualization/chart.py
@@ -1,0 +1,44 @@
+"""Visualization helpers using Plotly."""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+
+def candlestick_chart(
+    frame: pd.DataFrame,
+    predictions: Optional[pd.Series] = None,
+    prediction_horizon: int = 0,
+    title: str = "Candlestick Forecast",
+) -> go.Figure:
+    fig = go.Figure(
+        data=[
+            go.Candlestick(
+                x=frame["datetime"],
+                open=frame["open"],
+                high=frame["high"],
+                low=frame["low"],
+                close=frame["close"],
+                name="Observed",
+            )
+        ]
+    )
+    if predictions is not None and prediction_horizon > 0:
+        interval = frame["datetime"].diff().median()
+        if pd.isna(interval) or interval == pd.Timedelta(0):
+            interval = pd.Timedelta(hours=1)
+        future_index = frame["datetime"].iloc[-1] + interval * np.arange(1, prediction_horizon + 1)
+        fig.add_trace(
+            go.Scatter(
+                x=future_index,
+                y=predictions,
+                mode="lines",
+                name="Forecast",
+                line=dict(color="rgba(0, 200, 150, 0.7)", width=2, dash="dash"),
+            )
+        )
+    fig.update_layout(title=title, xaxis_title="Time", yaxis_title="Price")
+    return fig

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,75 @@
+import pandas as pd
+import torch
+
+from stonkex.data.datasets import (
+    CandlestickDataset,
+    NormalizationStats,
+    SequenceWindow,
+    split_train_validation,
+)
+
+
+def make_frame(rows: int = 120) -> pd.DataFrame:
+    data = {
+        "datetime": pd.date_range("2021-01-01", periods=rows, freq="H"),
+        "open": torch.linspace(0, 1, rows).numpy(),
+        "high": torch.linspace(0, 1, rows).numpy() + 0.1,
+        "low": torch.linspace(0, 1, rows).numpy() - 0.1,
+        "close": torch.linspace(0, 1, rows).numpy(),
+        "volume": torch.ones(rows).numpy(),
+    }
+    return pd.DataFrame(data)
+
+
+def test_dataset_window_shapes():
+    frame = make_frame()
+    window = SequenceWindow(input_window=32, horizon=8)
+    dataset = CandlestickDataset(frame, window)
+    sample_inputs, sample_targets = dataset[0]
+    assert sample_inputs.shape == (32, 5)
+    assert sample_targets.shape == (8,)
+
+
+def test_dataset_uses_shared_normalization():
+    frame = make_frame()
+    window = SequenceWindow(input_window=32, horizon=8)
+    train_dataset = CandlestickDataset(frame.iloc[:80], window)
+    stats = NormalizationStats(mean=train_dataset.mean, std=train_dataset.std)
+    val_dataset = CandlestickDataset(frame.iloc[80:], window, stats=stats)
+    assert torch.allclose(torch.tensor(stats.mean.to_numpy()), torch.tensor(train_dataset.mean.to_numpy()))
+    assert val_dataset.mean.equals(stats.mean)
+
+
+def test_grouped_dataset_builds_per_symbol_windows():
+    base = make_frame()
+    sym_a = base.copy()
+    sym_a["symbol"] = "AAA"
+    sym_b = base.copy()
+    sym_b["symbol"] = "BBB"
+    frame = pd.concat([sym_a, sym_b], ignore_index=True)
+    window = SequenceWindow(input_window=32, horizon=8)
+    dataset = CandlestickDataset(frame, window, group_column="symbol")
+    expected_per_symbol = len(base) - window.total_window + 1
+    assert len(dataset) == expected_per_symbol * 2
+    inputs, targets = dataset[-1]
+    assert inputs.shape == (32, 5)
+    assert targets.shape == (8,)
+
+
+def test_split_train_validation_grouped():
+    base = make_frame(40)
+    base["datetime"] = pd.to_datetime(base["datetime"], utc=True)
+    sym_a = base.copy()
+    sym_a["symbol"] = "AAA"
+    sym_b = base.copy()
+    sym_b["symbol"] = "BBB"
+    frame = pd.concat([sym_a, sym_b], ignore_index=True)
+    train, val = split_train_validation(frame, train_ratio=0.75, group_column="symbol")
+    assert set(train["symbol"].unique()) == {"AAA", "BBB"}
+    assert set(val["symbol"].unique()) == {"AAA", "BBB"}
+    for symbol in ("AAA", "BBB"):
+        total = len(frame[frame["symbol"] == symbol])
+        train_count = len(train[train["symbol"] == symbol])
+        val_count = len(val[val["symbol"] == symbol])
+        assert train_count + val_count == total
+        assert val_count >= 1

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,11 @@
+import torch
+
+from stonkex.models.transformer import TemporalTransformer, TransformerConfig
+
+
+def test_transformer_forward_shape():
+    config = TransformerConfig(input_dim=5, d_model=32, nhead=4, num_layers=2, dim_feedforward=64, horizon=6)
+    model = TemporalTransformer(config)
+    batch = torch.randn(3, 20, 5)
+    output = model(batch)
+    assert output.shape == (3, 6)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,0 +1,40 @@
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader
+
+from stonkex.data.datasets import CandlestickDataset, SequenceWindow
+from stonkex.models.transformer import TemporalTransformer, TransformerConfig
+from stonkex.training.trainer import Trainer
+
+
+def make_loader():
+    rows = 80
+    frame = pd.DataFrame(
+        {
+            "datetime": pd.date_range("2021-01-01", periods=rows, freq="H"),
+            "open": torch.linspace(0, 1, rows).numpy(),
+            "high": torch.linspace(0, 1, rows).numpy() + 0.1,
+            "low": torch.linspace(0, 1, rows).numpy() - 0.1,
+            "close": torch.linspace(0, 1, rows).numpy(),
+            "volume": torch.ones(rows).numpy(),
+        }
+    )
+    dataset = CandlestickDataset(frame, SequenceWindow(input_window=16, horizon=4))
+    return DataLoader(dataset, batch_size=8, shuffle=True)
+
+
+def test_trainer_runs_single_epoch():
+    loader = make_loader()
+    model = TemporalTransformer(TransformerConfig(input_dim=5, d_model=16, nhead=4, num_layers=1, dim_feedforward=32, horizon=4))
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    trainer = Trainer(
+        model=model,
+        optimizer=optimizer,
+        scheduler=None,
+        device=torch.device("cpu"),
+        mixed_precision=False,
+        max_grad_norm=1.0,
+        gradient_accumulation=1,
+        callbacks=[],
+    )
+    trainer.train(loader, epochs=1)


### PR DESCRIPTION
## Summary
- add a 70-symbol default universe module with helpers to download, resume, and load large multi-CSV datasets within a configurable size budget
- extend the training CLI and dataset utilities to respect per-symbol boundaries, support directories of CSV files, and improve grouped train/validation splits
- document the multi-stock workflow, add a bulk download script, and show the Hugging Face CPU launch flow using the new universe tooling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cda71345008330ab05e6a4631aba0a